### PR TITLE
Allow passing an OTP via env

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -81,7 +81,7 @@ func init() {
 		"generator",
 		"g",
 		"AWSU_TOKEN_GENERATOR",
-		"configure the token generator to 'yubikey' or 'manual'",
+		"configure the token generator to 'manual', 'provided', or 'yubikey'",
 	)
 
 	flag(rootCmd.PersistentFlags(),

--- a/source/provided/provided.go
+++ b/source/provided/provided.go
@@ -1,0 +1,27 @@
+package provided
+
+import (
+	"os"
+	"time"
+)
+
+// Provided is a generator that is based on input from the environment
+type Provided struct {
+}
+
+// New initializes a new provided generator
+func New() *Provided {
+
+	return &Provided{}
+}
+
+// Generate generates a new OTP by from the environment
+func (m *Provided) Generate(clock time.Time, name string) (string, error) {
+
+	return os.Getenv("AWSU_PROVIDED_OTP"), nil
+}
+
+// Name returns the name of this generator
+func (m *Provided) Name() string {
+	return "provided"
+}

--- a/strategy/session_token.go
+++ b/strategy/session_token.go
@@ -12,12 +12,16 @@ import (
 	"github.com/gesellix/awsu/log"
 	"github.com/gesellix/awsu/source"
 	"github.com/gesellix/awsu/source/manual"
+	"github.com/gesellix/awsu/source/provided"
 	"github.com/gesellix/awsu/source/yubikey"
 	"github.com/gesellix/awsu/strategy/credentials"
 	"github.com/gesellix/awsu/target/mfa"
 )
 
 const (
+	// GenProvided reads OTPs from the environment
+	GenProvided = "provided"
+
 	// GenManual is the "manual" (type-OTP-in) generator
 	GenManual = "manual"
 
@@ -126,6 +130,9 @@ func (s *SessionToken) generate(serial *string) (string, error) {
 
 	case GenManual:
 		g = manual.New()
+
+	case GenProvided:
+		g = provided.New()
 
 	default:
 		return "", fmt.Errorf(errUnknownGenerator, s.Generator)


### PR DESCRIPTION
Eases non-interactive usage of `eval $(awsu ...)`... but hey, we should read the docs more closely, right?
-> This one probably isn't necessary.